### PR TITLE
Large root folder improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Press `ctrl + alt + o` or type **Git Projects** in the Command Palette.
 | `openInDevMode`         | `false`            | `true`, `false`                                            |
 | `notificationsEnabled`  | `true`             | `true`, `false`                                            |
 | `showGitInfo`           | `true`             | `true`, `false`                                            |
+| `maxDepth`              | `5`                | Max number of directories to traverse from root            |
 
 ## Project-specific configuration  <a id="project-specific-configuration"></a>
 

--- a/lib/git-projects.coffee
+++ b/lib/git-projects.coffee
@@ -131,7 +131,7 @@ module.exports =
           return false
         
         dirDepth = _dir.split(path.sep).length;
-        return rootDepth + maxDepth < dirDepth
+        return rootDepth + maxDepth > dirDepth
       , =>
         sendCallback()
       )

--- a/lib/git-projects.coffee
+++ b/lib/git-projects.coffee
@@ -28,6 +28,11 @@ module.exports =
       type: "string"
       default: "Project name"
       enum: ["Project name", "Latest modification date", "Size"]
+    maxDepth:
+      title: "Max Folder Depth"
+      type: 'integer'
+      default: 5
+      minimum: 1
     openInDevMode:
       title: "Open in development mode"
       type: "boolean"
@@ -114,6 +119,9 @@ module.exports =
           
       return sendCallback() if @shouldIgnorePath(rootPath)
 
+      rootDepth = rootPath.split(path.sep).length
+      maxDepth = atom.config.get('git-projects.maxDepth')
+      
       fs.traverseTree(rootPath, (->), (_dir) =>
         return false if @shouldIgnorePath(_dir)
         if utils.isRepositorySync(_dir)
@@ -121,7 +129,9 @@ module.exports =
           unless project.ignored
             @projects.push(project)
           return false
-        return true
+        
+        dirDepth = _dir.split(path.sep).length;
+        return rootDepth + maxDepth < dirDepth
       , =>
         sendCallback()
       )

--- a/lib/views/projects-list-view.coffee
+++ b/lib/views/projects-list-view.coffee
@@ -50,10 +50,10 @@ class ProjectsListView extends SelectListView
     @loading.text "Looking for repositories ..."
     @loadingArea.show()
     @panel.show()
-    setTimeout( =>
-      @setItems(@controller.findGitRepos())
+    @controller.findGitRepos(null, (repos) =>
+      @setItems(repos)
       @focusFilterEditor()
-    , 0)
+    )
 
   viewForItem: (project) ->
     $$ ->

--- a/spec/git-projects-spec.coffee
+++ b/spec/git-projects-spec.coffee
@@ -22,15 +22,38 @@ describe "GitProjects", ->
 
   describe "findGitRepos", ->
     it "should return an array", ->
-      expect(GitProjects.findGitRepos()).toBeArray
-      expect(GitProjects.findGitRepos("~/workspace/;~/workspace; ~/workspace/fake")).toBeArray
-
+      asserts = 0;
+      runs(=>
+        GitProjects.findGitRepos(null, (repos) => 
+          expect(repos).toBeArray;
+          asserts++;
+        )
+        
+        GitProjects.findGitRepos("~/workspace/;~/workspace; ~/workspace/fake", (repos) =>
+          expect(repos).toBeArray;
+          asserts++;
+        )
+      )
+      waitsFor(=> asserts == 2)
+    
     it "should not contain any of the ignored patterns", ->
-      projects = GitProjects.findGitRepos("~/workspace/;~/workspace; ~/workspace/fake")
-      projects.forEach (project) ->
-        expect(project.path).not.toMatch( /node_modules|\.git/g )
-
+      done = false;
+      runs(=>
+        GitProjects.findGitRepos("~/workspace/;~/workspace; ~/workspace/fake", (projects) =>
+          projects.forEach (project) ->
+            expect(project.path).not.toMatch( /node_modules|\.git/g )
+          done = true;
+        )
+      )
+      waitsFor(=> done)
+    
     it "should not contain any of the ignored paths", ->
-      projects = GitProjects.findGitRepos("~/workspace/;~/workspace; ~/workspace/fake")
-      projects.forEach (project) ->
-        expect(project.path).not.toMatch( /\/workspace\/www/g )
+      done = false;
+      runs(=>
+        GitProjects.findGitRepos("~/workspace/;~/workspace; ~/workspace/fake", (projects) =>
+          projects.forEach (project) ->
+            expect(project.path).not.toMatch( /\/workspace\/www/g )
+          done = true;
+        )
+      )
+      waitsFor(=> done)


### PR DESCRIPTION
Hi! I like this plugin, thank you for making it!

I noticed that the plugin was very slow to start up in my "Code" folder. There are a _ton_ of projects in this folder, many of them are not git projects. I figured there may be other people in the same boat as me, and it would be great for them to have a good experience when first trying out the plugin.

To that end, I've made the directory listing async run asynchronously, which stops the UI from locking up for large projects.

Additionally, I've added a "max depth" option which puts a cap on the number of directories to traverse. It's defaulted to 5, but can be increased for more extreme circumstances.

These two features result in a much better UX for me when first launching the plugin with a large root folder, I hope you agree!

Thanks,
Sam