### PR TITLE
Fix callback behavior with multiple root paths

### DIFF
--- a/lib/git-projects.coffee
+++ b/lib/git-projects.coffee
@@ -111,7 +111,6 @@ module.exports =
 
     pathsChecked = 0
     rootPaths.forEach (rootPath) =>
-      pathsChecked++;
       
       sendCallback = =>
         if pathsChecked == rootPaths.size
@@ -133,6 +132,7 @@ module.exports =
         dirDepth = _dir.split(path.sep).length;
         return rootDepth + maxDepth > dirDepth
       , =>
+        pathsChecked++;
         sendCallback()
       )
 

--- a/lib/git-projects.coffee
+++ b/lib/git-projects.coffee
@@ -113,7 +113,7 @@ module.exports =
     rootPaths.forEach (rootPath) =>
       
       sendCallback = =>
-        if pathsChecked == rootPaths.size
+        if ++pathsChecked == rootPaths.size
           cb(utils.sortBy(@projects))
           
       return sendCallback() if @shouldIgnorePath(rootPath)
@@ -132,7 +132,6 @@ module.exports =
         dirDepth = _dir.split(path.sep).length;
         return rootDepth + maxDepth > dirDepth
       , =>
-        pathsChecked++;
         sendCallback()
       )
 


### PR DESCRIPTION
This is a bug I encountered with the new async code in #28. When multiple root paths are given, the callback was firing too early.