### PR TITLE
Cache git projects, and more optimizations

### DIFF
--- a/lib/find-git-repos-task.coffee
+++ b/lib/find-git-repos-task.coffee
@@ -1,0 +1,70 @@
+fs = require 'fs-plus'
+path = require 'path'
+utils = require './utils'
+
+Project = require './models/project'
+
+sortByFn = (_sortKey) ->
+  return (array) ->
+    utils.sortBy(_sortKey, array)
+
+shouldIgnorePathFn = (_ignoredPath, _ignoredPatterns) ->
+  # Determines if a path should be ignored based on the package settings
+  # Returns true if the given _path should be ignored, false otherwise
+  #
+  # _path - {String} the path to test
+  return (_path) ->
+    ignoredPaths = utils.parsePathString(_ignoredPath)
+    ignoredPattern = new RegExp((_ignoredPatterns || "").split(/\s*;\s*/g).join("|"), "g")
+    return true if ignoredPattern.test(_path)
+    return ignoredPaths and ignoredPaths.has(_path)
+
+
+# Finds all the git repositories recursively from the given root path(s)
+#
+# root - {String} the string of root paths to search from
+# maxDepth - {Number} max folder depth
+# sortBy - {Function} the configured `sortBy` function
+# shouldIgnorePath - {Function} the configured `shouldIgnorePath` function
+findGitRepos = (root, maxDepth, sortBy, shouldIgnorePath, cb) ->
+  projects = []
+  pathsChecked = 0
+  rootPaths = utils.parsePathString(root)
+
+  rootPaths.forEach (rootPath) ->
+
+    sendCallback = ->
+      if ++pathsChecked == rootPaths.size
+        cb(sortBy(projects))
+
+    return sendCallback() if shouldIgnorePath(rootPath)
+
+    rootDepth = rootPath.split(path.sep).length
+
+    fs.traverseTree(rootPath, (->), (_dir) ->
+      return false if shouldIgnorePath(_dir)
+      if utils.isRepositorySync(_dir)
+        project = new Project(_dir)
+        unless project.ignored
+          projects.push(project)
+        return false
+
+      dirDepth = _dir.split(path.sep).length
+      return rootDepth + maxDepth > dirDepth
+    , ->
+      sendCallback()
+    )
+
+
+module.exports = (rootPaths, config) ->
+  # Indicates that this task will be async.
+  # Call the `callback` to finish the task
+  callback = @async()
+
+  maxDepth = config.maxDepth
+  sortBy = sortByFn(config.sortBy)
+  shouldIgnorePath = shouldIgnorePathFn(config.ignoredPath, config.ignoredPatterns)
+
+  findGitRepos rootPaths, maxDepth, sortBy, shouldIgnorePath, (projects) ->
+    emit('found-repos', projects)
+    callback()

--- a/lib/git-projects.coffee
+++ b/lib/git-projects.coffee
@@ -50,15 +50,21 @@ module.exports =
       default: true
 
 
-  projects: []
+  projects: null
   view: null
 
   activate: (state) ->
     @checkForUpdates()
+    @projects = state.projectsCache?.map (project) ->
+      Project.deserialize(project)
+    @projects = @projects?.filter (project) ->
+      utils.isRepositorySync(project.path)
     atom.commands.add 'atom-workspace',
       'git-projects:toggle': =>
         @createView().toggle(@)
 
+  serialize: ->
+    projectsCache: @projects
 
   # Checks for updates by sending an ajax request to the latest package.json
   # hosted on Github.

--- a/lib/models/project.coffee
+++ b/lib/models/project.coffee
@@ -3,8 +3,10 @@ _path = require 'path'
 CSON = require 'season'
 fs = require 'fs'
 
-module.exports =
 class Project
+  @deserialize: (instance) ->
+    new ProjectDeserialized instance
+
   constructor: (@path) ->
     @icon = "icon-repo"
     @ignored = false
@@ -27,3 +29,12 @@ class Project
         @title = data['title'] if data['title']?
         @ignored = data['ignore'] if data['ignore']?
         @icon = data['icon'] if data['icon']?
+
+class ProjectDeserialized extends Project
+  constructor: (instance) ->
+    @path = instance.path
+    @icon = instance.icon
+    @ignored = instance.ignored
+    @title = instance.title
+
+module.exports = Project

--- a/lib/models/project.coffee
+++ b/lib/models/project.coffee
@@ -5,6 +5,7 @@ fs = require 'fs'
 
 {Task} = require 'atom'
 ReadGitInfoTask = require.resolve '../read-git-info-task'
+TaskPool = require '../task-pool'
 
 class Project
   # For caching
@@ -27,10 +28,10 @@ class Project
 
   readGitInfo: (cb) ->
     task = new Task(ReadGitInfoTask)
-    task.on 'result', (data) =>
+    TaskPool.add task, @path, (data) =>
       @branch = data.branch
       @dirty = data.dirty
-    task.start(@path, cb)
+      cb()
 
   hasGitInfo: ->
     @branch? and @dirty?

--- a/lib/read-git-info-task.coffee
+++ b/lib/read-git-info-task.coffee
@@ -1,0 +1,13 @@
+git = require 'git-utils'
+
+readGitInfo = (path) ->
+  repository = git.open path
+  branch: repository.getShortHead()
+  dirty: Object.keys(repository.getStatus()).length != 0
+
+module.exports = (path) ->
+  # Indicates that this task will be async.
+  # Call the `callback` to finish the task
+  callback = @async()
+  emit('result', readGitInfo(path))
+  callback()

--- a/lib/read-git-info-task.coffee
+++ b/lib/read-git-info-task.coffee
@@ -2,8 +2,12 @@ git = require 'git-utils'
 
 readGitInfo = (path) ->
   repository = git.open path
-  branch: repository.getShortHead()
-  dirty: Object.keys(repository.getStatus()).length != 0
+  result =
+    branch: repository.getShortHead()
+    dirty: Object.keys(repository.getStatus()).length != 0
+
+  repository.release()
+  return result
 
 module.exports = (path) ->
   # Indicates that this task will be async.

--- a/lib/task-pool.coffee
+++ b/lib/task-pool.coffee
@@ -1,0 +1,36 @@
+os = require 'os'
+
+class TaskPool
+  liveCount: 0
+  tasks: []
+  working: false
+
+  constructor: (@size=4) ->
+    @size = 3
+
+  run: ->
+    @working = true
+    interval = null
+
+    work = =>
+      return clearInterval(interval) unless @working
+      return if @liveCount >= @size
+      return @stop() unless @tasks.length
+
+      {task, args, callback} = @tasks.shift()
+      task.on 'result', callback
+
+      @liveCount++
+      task.start args..., => @liveCount--
+
+    interval = setInterval(work, 10)
+
+  stop: ->
+    @working = false
+
+  add: (task, args..., callback) ->
+    @tasks.push {task, args, callback}
+    @run() unless @working
+
+module.exports =
+  new TaskPool Math.max(os.cpus().length - 2, 1)

--- a/lib/task-pool.coffee
+++ b/lib/task-pool.coffee
@@ -6,7 +6,6 @@ class TaskPool
   working: false
 
   constructor: (@size=4) ->
-    @size = 3
 
   run: ->
     @working = true

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -22,9 +22,10 @@ isRepositorySync: (dir) ->
 
 
 # Returns a sorted {Array} of projects based on the package settings
+# sortKey - {String} the config value to sort by
 # array - {Array} of {Project}s to sort
-sortBy: (array) ->
-  array.sort cmp(sorts.get(atom.config.get('git-projects.sortBy')))
+sortBy: (sortKey, array) ->
+  array.sort cmp(sorts.get(sortKey))
 
 
 # Returns a {Set} of paths

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -18,7 +18,7 @@ module.exports =
 
 # Returns true if the passed dir is a Git repo
 isRepositorySync: (dir) ->
-  return dir? and git.open(dir)?
+  return dir? and fs.existsSync(path.join(dir,'.git'))
 
 
 # Returns a sorted {Array} of projects based on the package settings

--- a/lib/views/projects-list-view.coffee
+++ b/lib/views/projects-list-view.coffee
@@ -43,7 +43,6 @@ class ProjectsListView extends SelectListView
 
   hide: ->
     @panel?.hide()
-    @controller.clearProjectsList()
 
   show: ->
     @panel ?= atom.workspace.addModalPanel(item: this)

--- a/lib/views/projects-list-view.coffee
+++ b/lib/views/projects-list-view.coffee
@@ -6,6 +6,7 @@ Project = require '../models/project'
 module.exports =
 class ProjectsListView extends SelectListView
   controller: null
+  cachedViews: new Map
 
   activate: ->
     new ProjectsListView
@@ -45,6 +46,7 @@ class ProjectsListView extends SelectListView
     @panel?.hide()
 
   show: ->
+    @cachedViews.clear()
     @panel ?= atom.workspace.addModalPanel(item: this)
     @loading.text "Looking for repositories ..."
     @loadingArea.show()
@@ -76,6 +78,7 @@ class ProjectsListView extends SelectListView
     )
 
   viewForItem: (project) ->
+    if cachedView = @cachedViews.get(project) then return cachedView
     view = $$ ->
       @li class: 'two-lines', =>
         @div class: 'status status-added'
@@ -97,4 +100,6 @@ class ProjectsListView extends SelectListView
         project.readGitInfo ->
           createdSubview?.remove()
           subview()
+
+    @cachedViews.set(project, view)
     return view

--- a/lib/views/projects-list-view.coffee
+++ b/lib/views/projects-list-view.coffee
@@ -46,23 +46,24 @@ class ProjectsListView extends SelectListView
     @panel?.hide()
 
   show: ->
-    @cachedViews.clear()
     @panel ?= atom.workspace.addModalPanel(item: this)
     @loading.text "Looking for repositories ..."
     @loadingArea.show()
     @panel.show()
-
     # Show the cached projects right away
-    cachedProjects = @controller.projects
-    if cachedProjects?
-      @setItems(cachedProjects)
-      @focusFilterEditor()
-
+    @cachedProjects = @controller.projects
+    @setItems(@cachedProjects) if @cachedProjects?
+    @focusFilterEditor()
     # Then show the refreshed projects
-    @controller.findGitRepos(null, (repos) =>
+    setImmediate => @refreshItems()
+
+  refreshItems: ->
+    @cachedViews.clear()
+    @controller.findGitRepos null, (repos) =>
       projectMap = {}
-      cachedProjects?.forEach (project) ->
+      @cachedProjects?.forEach (project) ->
         projectMap[project.path] = project
+
       # Copy some properties from the cached objects
       # But mark the object as stale so they are refreshed
       repos.map (repo) ->
@@ -74,8 +75,6 @@ class ProjectsListView extends SelectListView
         return repo
 
       @setItems(repos)
-      @focusFilterEditor()
-    )
 
   viewForItem: (project) ->
     if cachedView = @cachedViews.get(project) then return cachedView

--- a/spec/utils-spec.coffee
+++ b/spec/utils-spec.coffee
@@ -17,8 +17,7 @@ describe "Utils", ->
 
   describe "sortBy", ->
     it "sorts by name when sortBy == 'Project name'", ->
-      atom.config.set('git-projects.sortBy', 'Project name')
-      expect(utils.sortBy(projects)).toEqual(projectsSortedByName)
+      expect(utils.sortBy('Project name', projects)).toEqual(projectsSortedByName)
 
   describe "parsePathString", ->
     it "should be a function",


### PR DESCRIPTION
Fixes #41 

## Before:
Notes:
- The git projects were found again every time the view is opened.
- Loading the items happened on the UI thread,
a68d82ba9bb5f9c50a124938cd9b52957e203e29 was a good attempt but it needed to be on a separate thread. Using Atom's [Task](https://atom.io/docs/api/v1.0.0/Task) to accomplish this.
- Anytime you type to filter down the list the git-utils::getStatus() and git-utils::getShortHead() functions would be called again for each list item because the item views were being unneccessarily recreated.
- The git getStatus call is expensive on large projects with a dirty index

![before](https://cloud.githubusercontent.com/assets/5132652/8428241/1b826430-1ed2-11e5-9aec-c8fdf1541b34.gif)

## After:
Notes:
- Git projects are found and loaded on a thread separate from the UI thread.
- Once they are loaded the git status states are lazy loaded for each item using separate Tasks.
- After the projects and status states are fetched then it is cached for the next time you open the view
- The next time you open the view it opens using the cached data right away, and in the background it starts the loading process again to refresh the data.
- Typing into the filter box doesn't trigger unnecessary item view recreation anymore.

![after](https://cloud.githubusercontent.com/assets/5132652/8428255/318ed970-1ed2-11e5-8f4d-1daa89553cc2.gif)

It would be nice if this code could be cleaned up further, and a more comprehensive spec added to cover the new caching features. (I got stuck when thinking about how to create the spec)