### PR TITLE
Added possibility to set the name of the repository as project name

### DIFF
--- a/lib/git-projects.coffee
+++ b/lib/git-projects.coffee
@@ -48,6 +48,10 @@ module.exports =
       description: "Display the branch and a status icon in the list of projects"
       type: "boolean"
       default: true
+    useNameOfTheRepository:
+      title: "Use the name of the repository as the name of project"
+      type: "boolean"
+      default: false
 
 
   projects: null

--- a/lib/models/project.coffee
+++ b/lib/models/project.coffee
@@ -16,6 +16,7 @@ class Project
   # Properties
   dirty: null
   branch: null
+  repositoryName: null
 
   @deserialize: (instance) ->
     new ProjectDeserialized instance
@@ -31,6 +32,7 @@ class Project
     TaskPool.add task, @path, (data) =>
       @branch = data.branch
       @dirty = data.dirty
+      @repositoryName = data.repositoryName
       cb()
 
   hasGitInfo: ->
@@ -53,5 +55,6 @@ class ProjectDeserialized extends Project
     @title = instance.title
     @dirty = instance.dirty
     @branch = instance.branch
+    @repositoryName = instance.repositoryName
 
 module.exports = Project

--- a/lib/read-git-info-task.coffee
+++ b/lib/read-git-info-task.coffee
@@ -1,8 +1,14 @@
 git = require 'git-utils'
+_path = require 'path'
 
 readGitInfo = (path) ->
   repository = git.open path
-  [..., repositoryName] = repository.getConfigValue('remote.origin.url').split "/"
+  repositoryUrl = repository.getConfigValue('remote.origin.url')
+  if (repositoryUrl)
+    [..., repositoryName] = repositoryUrl.split "/"
+  else
+    repositoryName = _path.basename(path)
+
   result =
     branch: repository.getShortHead()
     dirty: Object.keys(repository.getStatus()).length != 0

--- a/lib/read-git-info-task.coffee
+++ b/lib/read-git-info-task.coffee
@@ -2,9 +2,11 @@ git = require 'git-utils'
 
 readGitInfo = (path) ->
   repository = git.open path
+  [..., repositoryName] = repository.getConfigValue('remote.origin.url').split "/"
   result =
     branch: repository.getShortHead()
     dirty: Object.keys(repository.getStatus()).length != 0
+    repositoryName: repositoryName
 
   repository.release()
   return result

--- a/lib/views/projects-list-view.coffee
+++ b/lib/views/projects-list-view.coffee
@@ -97,6 +97,9 @@ class ProjectsListView extends SelectListView
 
   viewForItem: (project) ->
     titleKey = @getTitleKey()
+    if atom.config.get('git-projects.useNameOfTheRepository') and project.repositoryName == undefined
+      titleKey = 'title'
+
     if cachedView = @cachedViews.get(project) then return cachedView
     view = $$ ->
       @li class: 'two-lines', =>


### PR DESCRIPTION
Sometimes the repository is located deep inside the directory with the name of the project.
Example: http://take.ms/2WCYy - git inside `…/site`, in this case the name of the project was as "site", with a new option, name is taken from the name of the repository