### PR TITLE
ctrl+alt+shift+o to add to current window

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Or find the package in **Atom** &rarr; **Settings** &rarr; **Install** and searc
 
 ## Usage <a id="usage"></a>
 
-Press `ctrl + alt + o` or type **Git Projects** in the Command Palette.
+Press `ctrl + alt + o` or type **Git Projects: Toggle** in the Command Palette to open project in a new window.
+
+Press `ctrl + alt + shift + o` or type **Git Projects: Toggle Add** in the Command Palette to add project to current window.
 
 ## Settings <a id="settings"></a>
 

--- a/keymaps/git-projects.cson
+++ b/keymaps/git-projects.cson
@@ -9,3 +9,4 @@
 # https://atom.io/docs/latest/advanced/keymaps
 'atom-workspace':
   'ctrl-alt-o': 'git-projects:toggle'
+  'ctrl-alt-shift-o': 'git-projects:toggle-add'

--- a/lib/git-projects.coffee
+++ b/lib/git-projects.coffee
@@ -66,6 +66,10 @@ module.exports =
       'git-projects:toggle': =>
         @createView().toggle(@)
 
+    atom.commands.add 'atom-workspace',
+      'git-projects:toggle-add': =>
+        @createView().toggle(@, 'add')
+
   serialize: ->
     projectsCache: @projects
 
@@ -77,6 +81,11 @@ module.exports =
       pathsToOpen: [project.path]
       devMode: atom.config.get('git-projects.openInDevMode')
 
+  # Adds a project to the list of root paths.
+  #
+  # project - The {Project} to add.
+  addProject: (project) ->
+    atom.project.addPath project.path
 
   # Creates an instance of the list view
   createView: ->

--- a/lib/views/projects-list-view.coffee
+++ b/lib/views/projects-list-view.coffee
@@ -7,6 +7,7 @@ module.exports =
 class ProjectsListView extends SelectListView
   controller: null
   cachedViews: new Map
+  type: null
 
   activate: ->
     new ProjectsListView
@@ -25,7 +26,10 @@ class ProjectsListView extends SelectListView
     @hide()
 
   confirmed: (project) ->
-    @controller.openProject(project)
+    if @type is 'add'
+      @controller.addProject(project)
+    else
+      @controller.openProject(project)
     @cancel()
 
   getEmptyMessage: (itemCount, filteredItemCount) =>
@@ -35,8 +39,9 @@ class ProjectsListView extends SelectListView
     return msg unless itemCount
     return super
 
-  toggle: (controller) ->
+  toggle: (controller, type) ->
     @controller = controller
+    @type = type
     if @panel?.isVisible()
       @hide()
     else

--- a/menus/git-projects.cson
+++ b/menus/git-projects.cson
@@ -8,6 +8,10 @@
         {
           'label': 'Toggle Projects List'
           'command': 'git-projects:toggle'
+        },
+        {
+          'label': 'Toggle Projects List (Add To Project)'
+          'command': 'git-projects:toggle-add'
         }
       ]
     ]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "activationCommands": {
     "atom-workspace": [
-      "git-projects:toggle"
+      "git-projects:toggle",
+      "git-projects:toggle-add"
     ]
   },
   "keywords": [


### PR DESCRIPTION
I'm constantly using git-projects to open new windows but have to revert to cmd + shift + o to add a project to the current window. This adds the option to add shift to the mix and add to the current window instead of opening a new one. 